### PR TITLE
Stabilize knowledge persistence fallback

### DIFF
--- a/TODO_CHECKLIST.md
+++ b/TODO_CHECKLIST.md
@@ -1,0 +1,15 @@
+# TODO Checklist
+
+## Knowledge Persistence Audit
+- [DONE] Review current knowledge persistence flow (frontend `useKV` hook and server persistence API) to pinpoint why knowledge entries disappear when navigating tabs.
+  - Initial inspection reveals `useKV` re-runs its persistence hydration effect on every render because the `defaultValue` dependency is an unstable array literal. When the persistence service is offline (fetch errors), the hook overwrites local state with the default `[]`, wiping knowledge entries during tab switches that trigger re-renders.
+- [DONE] Design and implement fixes ensuring in-memory state is stable even when the persistence service is unavailable.
+  - Implemented ref-backed default handling and conditional hydration in `useKV` to prevent failed fetches from clobbering populated local caches, preserving knowledge entries during UI navigation even without the persistence backend.
+- [DONE] Add regression coverage verifying knowledge entries remain after state updates without a persistence backend.
+  - Added `tests/hooks/useKV.test.tsx` which simulates a delayed persistence response returning `undefined` and confirms local updates remain intact, along with hydration coverage for successful fetches.
+- [DONE] Document the persistence behaviour and testing steps for future contributors.
+  - Extended `docs/runbooks/memory-restore.md` with an appendix summarizing the new `useKV` offline fallback semantics and the `npx vitest run tests/hooks/useKV.test.tsx` regression command.
+
+## Broader System Review
+- [DONE] Identify any additional blockers or architectural risks discovered during persistence work and log actionable follow-ups.
+  - Logged a follow-up to split network errors from `404` misses in the persistence API so the UI can warn users about outage states instead of silently falling back to defaults.

--- a/docs/runbooks/memory-restore.md
+++ b/docs/runbooks/memory-restore.md
@@ -77,3 +77,16 @@ re-initialization, and collaboration history replay.
     `reports/drills/` for auditing.
   - Review `reports/drills/history.jsonl` to track previous drill outcomes and
     ensure anomalies are investigated promptly.
+
+## Appendix A – Frontend Persistence Notes
+
+- The React `useKV` hook now keeps an in-memory cache authoritative whenever the
+  persistence API is unreachable. Failed hydration attempts no longer overwrite
+  populated knowledge arrays; the hook only falls back to defaults when no
+  memory is present.
+- When investigating suspected regressions, reproduce the offline scenario by
+  mocking `fetchPersistedValue` to resolve `undefined` and verify that
+  previously added entries remain visible.
+- Run `npx vitest run tests/hooks/useKV.test.tsx` to execute the dedicated hook
+  regression suite that covers both the offline fallback and successful server
+  hydration flows.

--- a/tests/hooks/useKV.test.tsx
+++ b/tests/hooks/useKV.test.tsx
@@ -1,0 +1,61 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { clearKVStore, useKV } from '@/hooks/useKV'
+
+const persistenceMocks = vi.hoisted(() => ({
+  fetchPersistedValue: vi.fn<(key: string) => Promise<unknown | undefined>>(),
+  savePersistedValue: vi.fn<(key: string, value: unknown) => Promise<void>>()
+}))
+
+vi.mock('@/lib/api/persistence', () => persistenceMocks)
+
+const { fetchPersistedValue, savePersistedValue } = persistenceMocks
+
+describe('useKV', () => {
+  beforeEach(() => {
+    clearKVStore()
+    fetchPersistedValue.mockReset()
+    savePersistedValue.mockReset()
+  })
+
+  it('retains local updates when persistence hydration resolves undefined after the update', async () => {
+    let resolveFetch: (() => void) | undefined
+    fetchPersistedValue.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveFetch = () => resolve(undefined)
+        })
+    )
+    savePersistedValue.mockResolvedValue()
+
+    type Entry = { id: string }
+
+    const { result } = renderHook(() => useKV<Entry[]>('knowledge-base', () => []))
+
+    act(() => {
+      result.current[1]([{ id: 'entry-1' }])
+    })
+
+    await act(async () => {
+      resolveFetch?.()
+      await Promise.resolve()
+    })
+
+    expect(result.current[0]).toEqual([{ id: 'entry-1' }])
+    expect(fetchPersistedValue).toHaveBeenCalledTimes(1)
+  })
+
+  it('hydrates from persisted storage when available', async () => {
+    type Entry = { id: string }
+
+    fetchPersistedValue.mockResolvedValueOnce([{ id: 'persisted' }])
+    savePersistedValue.mockResolvedValue()
+
+    const { result } = renderHook(() => useKV<Entry[]>('knowledge-base', () => []))
+
+    await waitFor(() => {
+      expect(result.current[0]).toEqual([{ id: 'persisted' }])
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- prevent the `useKV` hook from overwriting cached knowledge when persistence fetches fail by stabilizing the default fallback
- add a dedicated regression suite for `useKV` and document the offline persistence workflow in the runbook
- capture the current investigation and follow-ups in TODO_CHECKLIST.md for transparency

## Testing
- npx vitest run tests/hooks/useKV.test.tsx tests/components/screens.test.tsx
- npx vitest run tests/components/screens.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68daf8d63ab88326bbe2ece35b7e5f2f