### PR TITLE
Persist agent settings tab selection

### DIFF
--- a/src/components/AgentSettings.tsx
+++ b/src/components/AgentSettings.tsx
@@ -1,9 +1,10 @@
-import { useState, useCallback } from 'react'
+import { useCallback } from 'react'
 import { Gear, Robot, Lightning } from '@phosphor-icons/react'
 import { toast } from 'sonner'
 
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useKV } from '@/hooks/useKV'
 import type { AgentConfig } from '@/types/agent'
 import type { AutonomousConfig } from '@/types/autonomous'
 import { DEFAULT_AUTONOMOUS_CONFIG } from '@/types/autonomous'
@@ -13,13 +14,22 @@ import { AutonomousSettingsPanel } from './agent-settings/AutonomousSettingsPane
 import { ProviderSettingsPanel } from './agent-settings/ProviderSettingsPanel'
 import { useAgentSettingsState } from './agent-settings/useAgentSettingsState'
 
+const SETTINGS_TABS = ['agents', 'providers', 'autonomous'] as const
+type SettingsTab = (typeof SETTINGS_TABS)[number]
+
+const isSettingsTab = (value: string): value is SettingsTab =>
+  SETTINGS_TABS.includes(value as SettingsTab)
+
 interface AgentSettingsProps {
   onConfigChange?: (configs: AgentConfig[]) => void
   onAutonomousChange?: (config: AutonomousConfig) => void
 }
 
 export function AgentSettings({ onConfigChange, onAutonomousChange }: AgentSettingsProps) {
-  const [activeSettingsTab, setActiveSettingsTab] = useState('agents')
+  const [activeSettingsTab, setActiveSettingsTab] = useKV<SettingsTab>(
+    'agent-settings.activeTab',
+    'agents'
+  )
 
   const {
     agentConfigs,
@@ -56,6 +66,15 @@ export function AgentSettings({ onConfigChange, onAutonomousChange }: AgentSetti
     toast.info('Autonomous mode can be started from the Collaboration tab')
   }, [])
 
+  const handleSettingsTabChange = useCallback(
+    (nextTab: string) => {
+      if (isSettingsTab(nextTab)) {
+        setActiveSettingsTab(nextTab)
+      }
+    },
+    [setActiveSettingsTab]
+  )
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -75,7 +94,7 @@ export function AgentSettings({ onConfigChange, onAutonomousChange }: AgentSetti
         </div>
       </div>
 
-      <Tabs value={activeSettingsTab} onValueChange={setActiveSettingsTab} className="space-y-6">
+      <Tabs value={activeSettingsTab} onValueChange={handleSettingsTabChange} className="space-y-6">
         <TabsList className="grid w-full grid-cols-3">
           <TabsTrigger value="agents" className="flex items-center gap-2">
             <Robot className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- persist the selected Agent Settings tab using KV storage so it survives re-renders
- validate tab changes against known tabs to prevent accidental resets while editing provider inputs

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ddeb1201c88326a88bd5bbd7027222